### PR TITLE
Use more explicit path for Error and Selector

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,8 +23,8 @@ mod search;
 mod selector;
 mod util;
 
-pub use error::Error;
-pub use selector::Selector;
+pub use self::error::Error;
+pub use self::selector::Selector;
 
 /// Parse a path, then search a file for all results that exactly match the specified
 /// path.


### PR DESCRIPTION
Hello @TedDriggs , thanks for this useful library.

`syn-select` fails to build with a slightly-older nightly, 1.32.0-nightly (15d770400 2018-11-06) in my case,  due to trouble correctly figuring out the path for the `Error` and `Selector` types exported in lib.rs

```
error[E0432]: unresolved import `error`
  --> src/lib.rs:26:9
   |
26 | pub use error::Error;
   |         ^^^^^ Did you mean `self::error`?

error[E0432]: unresolved import `selector`
  --> src/lib.rs:27:9
   |
27 | pub use selector::Selector;
   |         ^^^^^^^^ Did you mean `self::selector`?
```

In order to improve backwards compatibility, this PR makes the path resolution just a little bit more explicit for those types.  Because I was uncertain about contribution practices for this repo, I did not bump the version or add a note to the changelog, but can do so if requested.