### PR TITLE
Make syn_select::Selector implement Send and Sync

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,7 +42,7 @@ pub fn select(path: &str, file: &syn::File) -> Result<Vec<Item>, Error> {
 mod tests {
     use syn::Item;
 
-    use super::{select, util};
+    use super::{select, util, Selector};
 
     fn sample() -> syn::File {
         syn::parse_str(
@@ -88,6 +88,14 @@ mod tests {
 
     fn ident(ident: &str) -> syn::Ident {
         syn::parse_str::<syn::Ident>(ident).unwrap()
+    }
+
+    #[test]
+    fn autotraits() {
+        fn assert_send<T: Send>() {}
+        fn assert_sync<T: Sync>() {}
+        assert_send::<Selector>();
+        assert_sync::<Selector>();
     }
 
     #[test]

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -79,7 +79,7 @@ impl FromStr for Selector {
 #[derive(Debug, Clone)]
 pub(crate) enum SelectorSegment {
     /// A specific ident that must be exactly equal to match.
-    Ident(Ident),
+    Ident(String),
     /// A wildcard that matches any ident.
     Wildcard,
 }
@@ -92,8 +92,8 @@ impl FromStr for SelectorSegment {
             return Ok(SelectorSegment::Wildcard);
         }
 
-        syn::parse_str(input)
-            .map(SelectorSegment::Ident)
+        syn::parse_str::<Ident>(input)
+            .map(|ident| SelectorSegment::Ident(ident.to_string()))
             .map_err(|_| Error::invalid_segment(input.into()))
     }
 }
@@ -102,7 +102,7 @@ impl PartialEq<Ident> for SelectorSegment {
     fn eq(&self, other: &Ident) -> bool {
         match self {
             SelectorSegment::Wildcard => true,
-            SelectorSegment::Ident(ident) => ident == other,
+            SelectorSegment::Ident(ident) => other == ident,
         }
     }
 }


### PR DESCRIPTION
I need this in order to upgrade https://github.com/dtolnay/cargo-expand to clap 3.2. Clap's new typed API needs all the types used by typed CLI arguments to be Send + Sync.


```console
error[E0277]: `Rc<()>` cannot be sent between threads safely
    --> src/opts.rs:127:48
     |
127  |     #[clap(value_name = "ITEM", value_parser = parse_selector)]
     |                                 ------------   ^^^^^^^^^^^^^^ `Rc<()>` cannot be sent between threads safely
     |                                 |
     |                                 required by a bound introduced by this call
     |
     = help: within `syn_select::selector::SelectorSegment`, the trait `Send` is not implemented for `Rc<()>`
     = note: required because it appears within the type `proc_macro2::marker::ProcMacroAutoTraits`
     = note: required because it appears within the type `PhantomData<proc_macro2::marker::ProcMacroAutoTraits>`
     = note: required because it appears within the type `syn::Ident`
     = note: required because it appears within the type `syn_select::selector::SelectorSegment`
     = note: required because of the requirements on the impl of `Send` for `Unique<syn_select::selector::SelectorSegment>`
     = note: required because it appears within the type `alloc::raw_vec::RawVec<syn_select::selector::SelectorSegment>`
     = note: required because it appears within the type `Vec<syn_select::selector::SelectorSegment>`
     = note: required because it appears within the type `Selector`
     = note: required because of the requirements on the impl of `From<for<'r> fn(&'r str) -> std::result::Result<Selector, <Selector as FromStr>::Err> {parse_selector}>` for `ValueParser`
     = note: required because of the requirements on the impl of `Into<ValueParser>` for `for<'r> fn(&'r str) -> std::result::Result<Selector, <Selector as FromStr>::Err> {parse_selector}`
```